### PR TITLE
ecdsa package import error

### DIFF
--- a/mentalpoker/elliptic.py
+++ b/mentalpoker/elliptic.py
@@ -1,4 +1,4 @@
-from ecdsa import *
+from ecdsa import curves
 from .utils import *
 import binascii
 

--- a/mentalpoker/elliptic.py
+++ b/mentalpoker/elliptic.py
@@ -1,4 +1,4 @@
-from ecdsa import curves
+from ecdsa import curves, ellipticcurve
 from .utils import *
 import binascii
 


### PR DESCRIPTION
When using the wildcard import for `ecdsa` in `elliptic.py`, I received the following error:
```
Python 3.7.5 (default, Nov 12 2019, 15:49:04)
[Clang 11.0.0 (clang-1100.0.33.8)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from mentalpoker import DealerEC
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/brian/Code/mentalpoker/mentalpoker/__init__.py", line 1, in <module>
    from .dealer import *
  File "/Users/brian/Code/mentalpoker/mentalpoker/dealer.py", line 2, in <module>
    from .elliptic import *
  File "/Users/brian/Code/mentalpoker/mentalpoker/elliptic.py", line 1, in <module>
    from ecdsa import *
AttributeError: module 'ecdsa' has no attribute 'six'
```
importing `curves` only resolves the issue.